### PR TITLE
refactor(solve): test macro

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -5,10 +5,10 @@ extern crate log;
 use clap::Clap;
 use itertools::Itertools;
 
-use stoichkit::model::{Reaction, Substance};
-use stoichkit::solve::balance;
 use std::fs::read_to_string;
 use stoichkit::ext::parse_chemdraw_reaction;
+use stoichkit::model::{Reaction, Substance};
+use stoichkit::solve::balance;
 
 #[derive(Clap)]
 #[clap(version = "0.2.0")]
@@ -36,7 +36,7 @@ struct Unbal {
     #[clap(about = "Chemical equation [...reactants] = [...products]")]
     substances: Vec<String>,
     #[clap(short, conflicts_with = "substances")]
-    chemdraw_file: Option<String>
+    chemdraw_file: Option<String>,
 }
 
 impl Unbal {
@@ -56,16 +56,23 @@ impl Unbal {
                     .dropping(rx_len)
                     .map(|f| Substance::from_formula(f.as_str()))
                     .collect();
-                match (reagent_input.clone()?.len(), product_input.clone()?.len()) {
+                match (
+                    reagent_input.clone()?.len(),
+                    product_input.clone()?.len(),
+                ) {
                     (x, y) if x >= 1 as usize && y >= 1 as usize => Ok(()),
                     _ => Err("Must provide at least 1 reactant and 1 product"),
                 }?;
                 (reagent_input?, product_input?)
             }
             Some(f) => {
-                let s = read_to_string(f).map_err(|_e| format!("Could not read file {:?}", f))?;
+                let s = read_to_string(f)
+                    .map_err(|_e| format!("Could not read file {:?}", f))?;
                 let result = parse_chemdraw_reaction(s.as_str())?;
-                info!("Parsed reaction {:?} = {:?}", result.reactants, result.products);
+                info!(
+                    "Parsed reaction {:?} = {:?}",
+                    result.reactants, result.products
+                );
                 (result.reactants, result.products)
             }
         };

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -244,10 +244,10 @@ mod tests {
 
     macro_rules! parse_balanced_reagent {
         ($coef:tt($subst:tt)) => {
-            (stringify!($subst), $coef)
+            (stringify!($subst).to_string(), $coef)
         };
         ($subst:tt) => {
-            (stringify!($subst), 1)
+            (stringify!($subst).to_string(), 1)
         };
     }
 
@@ -264,14 +264,14 @@ mod tests {
                 _formulas_to_substances(products),
             )
             .unwrap();
-            assert_eq!(solution, vec![exp_reag, exp_prod])
+            assert_eq!(solution, (exp_reag, exp_prod))
         };
     }
 
     #[test]
     fn my_macro_test() {
         // TODO: parse expected in macro
-        balance!(H2O = O2 + H2 => 2(H2O) = O2 + 2(H2));
+        balance!(H2O = O2 + H2 => H2O = O2 + H2);
     }
 
     fn _formulas_to_substances(formulas: Vec<&str>) -> Vec<Substance> {

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -243,7 +243,7 @@ mod tests {
     use crate::solve::balance;
 
     macro_rules! parse_balanced_reagent {
-        ($coef:tt($subst:tt)) => {
+        (($subst:tt, $coef: tt)) => {
             (stringify!($subst).to_string(), $coef)
         };
         ($subst:tt) => {
@@ -252,7 +252,7 @@ mod tests {
     }
 
     // balance!(Al2 + Cl2 + NO3 = AlCl3)
-    macro_rules! balance {
+    macro_rules! expect_balanced {
         ($firstSubst:tt $( + $subst:tt)* = $firstProd:tt $( + $prod:tt)* => $firstOutSubst:tt $( + $outSubst:tt)* = $firstOutProd:tt $( + $outProd:tt)*) => { 
             // Al + Cl2 = AlCl3
             let reagents = vec![stringify!($firstSubst) $(,stringify!($subst))*];
@@ -268,12 +268,6 @@ mod tests {
         };
     }
 
-    #[test]
-    fn my_macro_test() {
-        // TODO: parse expected in macro
-        balance!(H2O = O2 + H2 => H2O = O2 + H2);
-    }
-
     fn _formulas_to_substances(formulas: Vec<&str>) -> Vec<Substance> {
         formulas
             .iter()
@@ -282,66 +276,47 @@ mod tests {
             .collect()
     }
 
-    fn _expect_solution(
-        reagents: Vec<&str>,
-        products: Vec<&str>,
-        expected: Vec<(&str, u32)>,
-    ) {
-        let solution = balance(
-            _formulas_to_substances(reagents),
-            _formulas_to_substances(products),
-        )
-        .unwrap();
-        let result: Vec<(&str, u32)> = solution
-            .0
-            .iter()
-            .chain(solution.1.iter())
-            .into_iter()
-            .map(|(s, c)| (s.as_str(), *c as u32))
-            .collect();
-        assert_eq!(result, expected)
+    #[test]
+    fn my_macro_test() {
+        // TODO: parse expected in macro
+        expect_balanced!(
+            H2O = O2 + H2 => 
+                (H2O, 2) = O2 + (H2, 2)
+        );
     }
 
     #[test]
     fn test_AlCl3() {
-        let rg = vec!["Al", "Cl2"];
-        let pd = vec!["AlCl3"];
-        let expected = vec![("Al", 2), ("Cl2", 3), ("AlCl3", 2)];
-        _expect_solution(rg, pd, expected)
+        expect_balanced!(
+            Al + Cl2 = AlCl3 => 
+                (Al, 2) + (Cl2, 3) = (AlCl3, 2)
+        );
     }
 
     #[test]
     // C6H5COOH + O2 = CO2 + H2O
     fn test_CO2() {
-        let rg = vec!["C6H5COOH", "O2"];
-        let pd = vec!["CO2", "H2O"];
-        let expected =
-            vec![("C6H5COOH", 2), ("O2", 15), ("CO2", 14), ("H2O", 6)];
-        _expect_solution(rg, pd, expected)
+        expect_balanced!(
+            C6H5COOH + O2 = CO2 + H2O =>
+                (C6H5COOH, 2) + (O2, 15) = (CO2, 14) + (H2O, 6)
+        );
     }
 
     #[test]
     // KMnO4 + HCl = KCl + MnCl2 + H2O + Cl2
     fn test_KMnO4() {
-        let rg = vec!["KMnO4", "HCl"];
-        let pd = vec!["KCl", "MnCl2", "H2O", "Cl2"];
-        let expected = vec![
-            ("KMnO4", 2),
-            ("HCl", 16),
-            ("KCl", 2),
-            ("MnCl2", 2),
-            ("H2O", 8),
-            ("Cl2", 5),
-        ];
-        _expect_solution(rg, pd, expected)
+        expect_balanced!(
+            KMnO4 + HCl = KCl + MnCl2 + H2O + Cl2 =>
+                (KMnO4, 2) + (HCl, 16) = (KCl, 2) + (MnCl2, 2) + (H2O, 8) + (Cl2, 5)
+        );
     }
 
     #[test]
     fn test_H2O() {
-        let rg = vec!["H2", "O2"];
-        let pd = vec!["H2O"];
-        let expected = vec![("H2", 2), ("O2", 1), ("H2O", 2)];
-        _expect_solution(rg, pd, expected)
+        expect_balanced!(
+            H2 + O2 = H2O =>
+                (H2, 2) + (O2, 1) = (H2O, 2)
+        );
     }
 
     #[test]

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -253,7 +253,7 @@ mod tests {
 
     // balance!(Al2 + Cl2 + NO3 = AlCl3)
     macro_rules! expect_balanced {
-        ($firstSubst:tt $( + $subst:tt)* = $firstProd:tt $( + $prod:tt)* => $firstOutSubst:tt $( + $outSubst:tt)* = $firstOutProd:tt $( + $outProd:tt)*) => { 
+        ($firstSubst:tt $( + $subst:tt)* = $firstProd:tt $( + $prod:tt)* => $firstOutSubst:tt $( + $outSubst:tt)* = $firstOutProd:tt $( + $outProd:tt)*) => {
             // Al + Cl2 = AlCl3
             let reagents = vec![stringify!($firstSubst) $(,stringify!($subst))*];
             let products = vec![stringify!($firstProd) $(,stringify!($prod))*];
@@ -275,20 +275,11 @@ mod tests {
             .map(|f| Substance::new(f, 1.0, None).unwrap())
             .collect()
     }
-
-    #[test]
-    fn my_macro_test() {
-        // TODO: parse expected in macro
-        expect_balanced!(
-            H2O = O2 + H2 => 
-                (H2O, 2) = O2 + (H2, 2)
-        );
-    }
-
+    
     #[test]
     fn test_AlCl3() {
         expect_balanced!(
-            Al + Cl2 = AlCl3 => 
+            Al + Cl2 = AlCl3 =>
                 (Al, 2) + (Cl2, 3) = (AlCl3, 2)
         );
     }

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -251,7 +251,9 @@ mod tests {
         };
     }
 
-    // balance!(Al2 + Cl2 + NO3 = AlCl3)
+    /**
+       e.x. expect_balanced!(H2O = H2 + O2 => (H2O, 2) = (H2, 2) + O2)
+    */
     macro_rules! expect_balanced {
         ($reactSubst:tt $( + $reactSubstTail:tt)* = $prodSubst:tt $( + $prodSubstTail:tt)* => $expectedReactant:tt $( + $expectedReactantTail:tt)* = $expectedProduct:tt $( + $expectedProductTail:tt)*) => {
             // Al + Cl2 = AlCl3

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -242,6 +242,38 @@ mod tests {
     use crate::model::*;
     use crate::solve::balance;
 
+    macro_rules! parse_balanced_reagent {
+        ($coef:tt($subst:tt)) => {
+            (stringify!($subst), $coef)
+        };
+        ($subst:tt) => {
+            (stringify!($subst), 1)
+        };
+    }
+
+    // balance!(Al2 + Cl2 + NO3 = AlCl3)
+    macro_rules! balance {
+        ($firstSubst:tt $( + $subst:tt)* = $firstProd:tt $( + $prod:tt)* => $firstOutSubst:tt $( + $outSubst:tt)* = $firstOutProd:tt $( + $outProd:tt)*) => { 
+            // Al + Cl2 = AlCl3
+            let reagents = vec![stringify!($firstSubst) $(,stringify!($subst))*];
+            let products = vec![stringify!($firstProd) $(,stringify!($prod))*];
+            let exp_reag = vec![parse_balanced_reagent!($firstOutSubst) $(, parse_balanced_reagent!($outSubst))*];
+            let exp_prod = vec![parse_balanced_reagent!($firstOutProd) $(, parse_balanced_reagent!($outProd))*];
+            let solution = balance(
+                _formulas_to_substances(reagents),
+                _formulas_to_substances(products),
+            )
+            .unwrap();
+            assert_eq!(solution, vec![exp_reag, exp_prod])
+        };
+    }
+
+    #[test]
+    fn my_macro_test() {
+        // TODO: parse expected in macro
+        balance!(H2O = O2 + H2 => 2(H2O) = O2 + 2(H2));
+    }
+
     fn _formulas_to_substances(formulas: Vec<&str>) -> Vec<Substance> {
         formulas
             .iter()

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -275,7 +275,7 @@ mod tests {
             .map(|f| Substance::new(f, 1.0, None).unwrap())
             .collect()
     }
-    
+
     #[test]
     fn test_AlCl3() {
         expect_balanced!(

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -253,12 +253,12 @@ mod tests {
 
     // balance!(Al2 + Cl2 + NO3 = AlCl3)
     macro_rules! expect_balanced {
-        ($firstSubst:tt $( + $subst:tt)* = $firstProd:tt $( + $prod:tt)* => $firstOutSubst:tt $( + $outSubst:tt)* = $firstOutProd:tt $( + $outProd:tt)*) => {
+        ($reactSubst:tt $( + $reactSubstTail:tt)* = $prodSubst:tt $( + $prodSubstTail:tt)* => $expectedReactant:tt $( + $expectedReactantTail:tt)* = $expectedProduct:tt $( + $expectedProductTail:tt)*) => {
             // Al + Cl2 = AlCl3
-            let reagents = vec![stringify!($firstSubst) $(,stringify!($subst))*];
-            let products = vec![stringify!($firstProd) $(,stringify!($prod))*];
-            let exp_reag = vec![parse_balanced_reagent!($firstOutSubst) $(, parse_balanced_reagent!($outSubst))*];
-            let exp_prod = vec![parse_balanced_reagent!($firstOutProd) $(, parse_balanced_reagent!($outProd))*];
+            let reagents = vec![stringify!($reactSubst) $(,stringify!($reactSubstTail))*];
+            let products = vec![stringify!($prodSubst) $(,stringify!($prodSubstTail))*];
+            let exp_reag = vec![parse_balanced_reagent!($expectedReactant) $(, parse_balanced_reagent!($expectedReactantTail))*];
+            let exp_prod = vec![parse_balanced_reagent!($expectedProduct) $(, parse_balanced_reagent!($expectedProductTail))*];
             let solution = balance(
                 _formulas_to_substances(reagents),
                 _formulas_to_substances(products),


### PR DESCRIPTION
Changes
---
- `expect_balanced!` macro makes it easier to write solver test cases
  - accepts one token: `[...substance +] = [...substance +] => [...reagent +] = [...reagent +]`
    - where `reagent` == `FORMULA` | `(FORMULA, COEFFICIENT)`

Note
--- 
- could not get `2xH2O` or `2(H2O)` token syntax to match for `reagent`, so resorted to tuple syntax