### PR TITLE
refactor(Element): replace ptable Element with custom Element struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,23 +278,23 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3e176191bc4faad357e3122c4747aa098ac880e88b168f106386128736cf4a"
+checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
 dependencies = [
  "num-bigint",
- "num-complex 0.3.0",
+ "num-complex 0.3.1",
  "num-integer",
  "num-iter",
- "num-rational 0.3.0",
+ "num-rational 0.3.2",
  "num-traits",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
+checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -313,18 +313,18 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05ad05bd8977050b171b3f6b48175fea6e0565b7981059b486075e1026a9fb5"
+checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
  "num-bigint",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
  "libm",
@@ -397,6 +397,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
 dependencies = [
  "proc-macro-hack",
+]
+
+[[package]]
+name = "periodic-table-on-an-enum"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce462378b3f87d2ce8e615ad6596767655b10c7bb9e071a586ddd3f8c5c9351"
+dependencies = [
+ "json",
 ]
 
 [[package]]
@@ -444,16 +453,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid",
-]
-
-[[package]]
-name = "ptable"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99debb0d2a2f25a412de14f288ec68e5110270d540eed4e2df940abffb7316c"
-dependencies = [
- "json",
- "memchr",
 ]
 
 [[package]]
@@ -663,7 +662,7 @@ dependencies = [
  "log",
  "nalgebra",
  "num",
- "ptable",
+ "periodic-table-on-an-enum",
  "rug",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ clap = { version = "3.0.0-beta.1", features = ["derive"] }
 nalgebra = "0.21.1"
 
 rug = { version = "1.9.0", features = ['integer', 'rational' ] }
-ptable = "0.3.2"
+periodic-table-on-an-enum = "0.3.2"
 num = "0.3.0"
 itertools = "0.9.0"
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
-use ptable::Element;
+use periodic_table_on_an_enum::Element as PElement;
 
 use crate::molecule::molecular_weight;
 use crate::parse::parse_formula;
@@ -14,6 +14,30 @@ pub struct Substance {
     molar_mass: f32,
     pub molar_coefficient: u32,
 }
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Element {
+    element: PElement,
+}
+
+impl Element {
+    pub fn from_symbol(sym: &str) -> Option<Element> {
+        PElement::from_symbol(sym).map(Element::from_pt_element)
+    }
+
+    pub fn from_atomic_number(z: usize) -> Option<Element> {
+        PElement::from_atomic_number(z).map(Element::from_pt_element)
+    }
+
+    fn from_pt_element(element: PElement) -> Element {
+        Element { element }
+    }
+
+    pub fn get_atomic_mass(&self) -> f32 {
+        self.element.get_atomic_mass()
+    }
+}
+
 
 impl Substance {
     pub fn from_formula(formula: &str) -> Result<Substance, String> {

--- a/src/molecule.rs
+++ b/src/molecule.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use ptable::Element;
+use crate::model::Element;
 
 pub fn molecular_weight(atoms: HashMap<Element, u32>) -> Result<f32, String> {
     let mut weight: f32 = 0 as f32;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
 use std::panic;
 
-use ptable::Element;
+use crate::model::Element;
 
 fn get_element(symbol: &str) -> Result<Element, String> {
     match symbol.chars().all(|c| c.is_ascii_alphabetic()) {
@@ -151,8 +151,7 @@ mod tests {
     use std::collections::hash_map::RandomState;
     use std::collections::HashMap;
 
-    use ptable::Element;
-
+    use crate::model::Element;
     use crate::parse::parse_formula;
     use crate::test_utils::e;
 

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -4,10 +4,10 @@ use std::collections::{HashMap, HashSet};
 use itertools::Itertools;
 use nalgebra::DMatrix;
 use num::integer::lcm;
-use ptable::Element;
 use rug::Rational;
 
-use crate::model::Substance;
+use crate::model::{Substance, Element};
+
 
 pub fn balance(
     reagents: Vec<Substance>,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use ptable::Element;
+use crate::model::Element;
 
 #[allow(dead_code)]
 pub fn e(expected: HashMap<&str, u32>) -> HashMap<Element, u32> {


### PR DESCRIPTION
ptable changed names, so it was a good idea to use our own Element facade anyway, to decouple the implementation